### PR TITLE
listen_tcpv4: add an optional argument for TCP keepalive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   - PACKAGE="mirage-stack"
   - PINS="mirage-stack-lwt:."
   - REVDEPS=true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+v1.2.0 2017-09-06
+-----------------
+
+- add an optional argument ?keepalive to `listen_tcpv4` which allows TCP
+  keepalives on accepted connections.
+- jbuilder is now a build dependency
+
 v1.1.0 2017-06-16
 -----------------
 

--- a/mirage-stack-lwt.opam
+++ b/mirage-stack-lwt.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
+  "jbuilder" {build & >="1.0+beta9"}
   "mirage-stack" {>= "1.0.0"}
   "ipaddr"
   "lwt"

--- a/mirage-stack.opam
+++ b/mirage-stack.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "jbuilder" {>="1.0+beta9"}
+  "jbuilder" {build & >="1.0+beta9"}
   "mirage-device" {>= "1.0.0"}
   "mirage-protocols" {>= "1.0.0"}
   "fmt"

--- a/mirage-stack.opam
+++ b/mirage-stack.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
   "mirage-device" {>= "1.0.0"}
-  "mirage-protocols" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.3.0"}
   "fmt"
 ]
 

--- a/src/mirage_stack.ml
+++ b/src/mirage_stack.ml
@@ -64,12 +64,15 @@ module type V4 = sig
       Multiple bindings to the same port will overwrite previous
       bindings, so callbacks will not chain if ports clash. *)
 
-  val listen_tcpv4: t -> port:int -> TCPV4.callback -> unit
-  (** [listen_tcpv4 t ~port cb] registers the [cb] callback on the
-      TCPv4 [port] and immediatey return.  If [port] is invalid (not
+  val listen_tcpv4: ?keepalive:Mirage_protocols.Keepalive.t
+    -> t -> port:int -> TCPV4.callback -> unit
+  (** [listen_tcpv4 ~keepalive t ~port cb] registers the [cb] callback
+      on the TCPv4 [port] and immediatey return.  If [port] is invalid (not
       between 0 and 65535 inclusive), it raises [Invalid_argument].
       Multiple bindings to the same port will overwrite previous
-      bindings, so callbacks will not chain if ports clash. *)
+      bindings, so callbacks will not chain if ports clash.
+      If [~keepalive] is provided then these keepalive settings will be
+      applied to the accepted connections before the callback is called. *)
 
   val listen: t -> unit io
   (** [listen t] requests that the stack listen for traffic on the

--- a/src/mirage_stack.ml
+++ b/src/mirage_stack.ml
@@ -65,7 +65,7 @@ module type V4 = sig
       bindings, so callbacks will not chain if ports clash. *)
 
   val listen_tcpv4: ?keepalive:Mirage_protocols.Keepalive.t
-    -> t -> port:int -> TCPV4.callback -> unit
+    -> t -> port:int -> (TCPV4.flow -> unit io) -> unit
   (** [listen_tcpv4 ~keepalive t ~port cb] registers the [cb] callback
       on the TCPv4 [port] and immediatey return.  If [port] is invalid (not
       between 0 and 65535 inclusive), it raises [Invalid_argument].


### PR DESCRIPTION
This corresponds to [mirage/mirage-protocols#8]

This PR adds an optional `?keepalive` argument to `listen_tcpv4` which allows the server to use TCP keep-alive on accepted connections.

Also
- opam: make `jbuilder` a `build` dependency
- update `CHANGES.md` for `v1.2.0`