### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-stack-lwt.opam
+++ b/mirage-stack-lwt.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-stack/"
 bug-reports: "https://github.com/mirage/mirage-stack/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-stack" {>= "1.3.0"}
   "ipaddr"
   "lwt"

--- a/mirage-stack.opam
+++ b/mirage-stack.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-stack/"
 bug-reports: "https://github.com/mirage/mirage-stack/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-device" {>= "1.0.0"}
   "mirage-protocols" {>= "1.4.0"}
   "fmt"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.